### PR TITLE
Fixed bug where course names that include certain characters throw error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.ipynb_checkpoints/
 output/*.csv
 .DS_Store
+
+__pycache__

--- a/Get CSV of Group Members.ipynb
+++ b/Get CSV of Group Members.ipynb
@@ -72,9 +72,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.4 64-bit ('la_data': conda)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python37464bitladataconda59808c641db24bad8e09b4d768e10fd4"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -86,7 +86,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/src/get_group_csv.py
+++ b/src/get_group_csv.py
@@ -3,7 +3,7 @@ from canvasapi import Canvas
 import getpass
 import sys
 from IPython.display import display, HTML
-from helpers import _create_csv
+from helpers import _create_csv, slugify
 from datetime import datetime
 from interface import get_user_inputs, shut_down
 from dotenv import load_dotenv
@@ -63,7 +63,7 @@ def main():
     df = get_group_data(settings.course)
     
     display(df)
-    output_name = "{}/{}_{}_Group Information_{}.csv".format("output", course_id, settings.course.name, timestamp)
+    output_name = "{}/{}_{}_Group_Information_{}.csv".format("output", course_id, slugify(settings.course.name), timestamp)
     _create_csv(df, output_name)
 
 if __name__ == "__main__":

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,14 +1,9 @@
 
 ## Functions I seem to use over and over
 
-from canvasapi import Canvas
-import getpass
-import sys
-import pandas as pd
-import re
-import ast
 from interface import shut_down
-
+import unicodedata
+import re
 
 def _create_csv(df, output_name):
     print(df.head())
@@ -26,6 +21,17 @@ def _create_csv(df, output_name):
             print("Please enter 'y' to accept or 'n' to exit\n")
             continue
 
-
+def slugify(value):
+    """
+    Taken and modified from https://github.com/django/django/blob/master/django/utils/text.py
+    Convert spaces or repeated ashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    value = str(value)
+    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = value.replace('/', '-')
+    value = re.sub(r'[^\w\s-]', '', value.lower())
+    return re.sub(r'[-\s]+', '-', value).strip('-_')
 
 


### PR DESCRIPTION
In researching our problem, I learned about a useful programming concept called "slug"

> Slug is used to make a name that is not acceptable for various reasons - e.g. containing special characters, too long, mixed-case, etc. - appropriate for the target usage

It's commonly used in Django to take a resource name and make it 'URL friendly' so that it can be accessible via the web.

This is more-or-less exactly what we're trying to do as well given that URL's behave similar to file paths and don't allow the same types of characters. For example '/' or '?' or '#' or even whitespaces.

What I've done is take and slightly modified the `slugify()` function from Django (hailed as the gold standard for this type of thing) and put it in our helpers.

I call this on the course name before the .csv gets created resulting in a file name like:

`output/4031_teaching-online-playbook-v119-01-12-2021_Group_Information_2021-01-18_103016`

instead of before:

`output/4031_Teaching Online Playbook - V1.19 - 01/12/2021_Group Information_2021-01-18_103016.csv`